### PR TITLE
Initial Cache and Error Handling

### DIFF
--- a/src/main/java/gov/cida/cdat/io/IO.java
+++ b/src/main/java/gov/cida/cdat/io/IO.java
@@ -112,7 +112,7 @@ public final class IO {
 	}
 	private static int read(InputStream source, byte[] buffer) throws ProducerException {
 		try {
-			Thread.sleep(250); // TODO this is here for testing
+			//Thread.sleep(250); // TODO this is here for testing
 			return source.read(buffer);
 		} catch (Exception e) {
 			throw new ProducerException("Error reading from producer stream", e);

--- a/src/main/java/gov/cida/cdat/io/SplitOutputStream.java
+++ b/src/main/java/gov/cida/cdat/io/SplitOutputStream.java
@@ -1,0 +1,115 @@
+package gov.cida.cdat.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SplitOutputStream extends OutputStream {
+
+	private OutputStream[] targets;
+	private final Map<String,Exception> errors;
+	
+	public SplitOutputStream(OutputStream ... targets) {
+		this.targets = targets;
+		errors = new HashMap<String, Exception>();
+	}
+	
+	/**
+	 * updates status and delegates to target output streams
+	 */
+	@Override
+	public void write(int b) throws IOException {
+		for (OutputStream target : targets) {
+			try {
+				target.write(b);
+			} catch (Exception e) {
+				manageException(target, e);
+			}
+		}
+	}
+
+	/**
+	 * updates status and delegates to target output streams
+	 */
+	@Override
+	public void write(byte[] bytes) throws IOException {
+		for (OutputStream target : targets) {
+			try {
+				target.write(bytes);
+			} catch (Exception e) {
+				manageException(target, e);
+			}
+		}
+	}
+	
+	/**
+	 * updates status and delegates to target output streams
+	 */
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		for (OutputStream target : targets) {
+			try {
+				target.write(b, off, len);
+			} catch (Exception e) {
+				manageException(target, e);
+			}
+		}
+	}
+
+	/**
+	 * closes the wrapped output streams 
+	 */
+	@Override
+	public void close() throws IOException {
+		for (OutputStream target : targets) {
+			Closer.close(target);
+		}
+		targets = null;
+	}
+	
+	/**
+	 * flush all target streams
+	 */
+	@Override
+	public void flush() throws IOException {
+		for (OutputStream target : targets) {
+			try {
+				target.flush();
+			} catch (Exception e) {
+				manageException(target, e);
+			}
+		}
+	}
+	
+	/**
+	 * helper method that can be enhanced in one location
+	 * @param target the stream that is in trouble
+	 * @param e the exception that the stream experienced
+	 */
+	void manageException(OutputStream target, Exception e) {
+		if (null==target) {
+			return;
+		}
+		errors.put(target.getClass().getName(), e);
+	}
+	/**
+	 * @return true if any stream threw an exception
+	 */
+	public boolean hasErrors() {
+		return ! errors.isEmpty();
+	}
+	/**
+	 * @return the number of streams that had an exception
+	 */
+	public int errorCount() {
+		return errors.size();
+	}
+	/**
+	 * @return A protected copy of all recent exceptions for streams
+	 */
+	public Map<String,Exception> getErrors() {
+		// protective copy
+		return new HashMap<String,Exception>(errors);
+	}
+}

--- a/src/main/java/gov/cida/cdat/io/stream/ChainedStreamContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/ChainedStreamContainer.java
@@ -1,0 +1,54 @@
+package gov.cida.cdat.io.stream;
+
+import gov.cida.cdat.exception.StreamInitException;
+import gov.cida.cdat.io.Closer;
+
+import java.io.OutputStream;
+
+public abstract class ChainedStreamContainer<S extends OutputStream> extends StreamContainer<OutputStream> {
+
+	private StreamContainer<OutputStream> target;
+	private S stream;
+
+	public ChainedStreamContainer(StreamContainer<OutputStream> target) {
+		this.target = target;
+	}
+	
+	@Override
+	protected String getName() {
+		return getClass().getName();
+	}
+
+	
+	/**
+	 * This is the init for ChainedStreams
+	 * @param stream the given the stream of the chained 'parent'
+	 * @return should return the stream this container is designed
+	 */
+	protected abstract S chain(OutputStream stream);
+	
+	
+	@Override
+	public S init() throws StreamInitException {
+		// TODO does it make sense for init() to call another open
+		// TODO I would like init() to be the chaining and open to be the this action
+		// for now it is necessary for chaining
+		stream = chain( target.open() );
+		return stream;
+	}
+	
+	
+	@Override
+	protected final void cleanup() {
+		Closer.close(target);
+	}
+	
+	/**
+	 * This is a specific getStream that is typed to the chain 
+	 * @return
+	 */
+	public final S getChainedStream() {
+		// TODO try refactoring the generics to remove this method
+		return stream;
+	}
+}

--- a/src/main/java/gov/cida/cdat/io/stream/DataPipe.java
+++ b/src/main/java/gov/cida/cdat/io/stream/DataPipe.java
@@ -12,7 +12,7 @@ import java.io.OutputStream;
 
 public class DataPipe implements Openable<InputStream>, Closeable {
 	
-	public static final int DEFAULT_DURATION = 5000;
+	public static final int DEFAULT_DURATION = 10000; // TODO make configurable
 	public static final int FULL_DURATION    = -1;
 	
 	private final StreamContainer<InputStream>  producer;

--- a/src/main/java/gov/cida/cdat/io/stream/FileStreamContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/FileStreamContainer.java
@@ -7,11 +7,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class FileStream extends StreamContainer<InputStream> {
+public class FileStreamContainer extends StreamContainer<InputStream> {
 
 	private final File file;
 	
-	public FileStream(File file) {
+	public FileStreamContainer(File file) {
 		this.file = file;
 	}
 

--- a/src/main/java/gov/cida/cdat/io/stream/HttpRequestContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/HttpRequestContainer.java
@@ -7,11 +7,11 @@ import java.io.InputStream;
 
 import javax.servlet.http.HttpServletRequest;
 
-public class HttpRequestStream extends StreamContainer<InputStream> {
+public class HttpRequestContainer extends StreamContainer<InputStream> {
 
 	private final HttpServletRequest request;
 	
-	public HttpRequestStream(HttpServletRequest request) {
+	public HttpRequestContainer(HttpServletRequest request) {
 		this.request = request;
 	}
 	

--- a/src/main/java/gov/cida/cdat/io/stream/HttpResponseContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/HttpResponseContainer.java
@@ -7,11 +7,11 @@ import java.io.OutputStream;
 
 import javax.servlet.http.HttpServletResponse;
 
-public class HttpResponseStream extends StreamContainer<OutputStream> {
+public class HttpResponseContainer extends StreamContainer<OutputStream> {
 	
 	private final HttpServletResponse response;
 	
-	public HttpResponseStream(HttpServletResponse response) {
+	public HttpResponseContainer(HttpServletResponse response) {
 		this.response = response;
 	}
 	

--- a/src/main/java/gov/cida/cdat/io/stream/SimpleStreamContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/SimpleStreamContainer.java
@@ -4,12 +4,12 @@ import gov.cida.cdat.exception.StreamInitException;
 
 import java.io.Closeable;
 
-public final class SimpleStream<S extends Closeable> extends StreamContainer<S> {
+public final class SimpleStreamContainer<S extends Closeable> extends StreamContainer<S> {
 
 	// simple stream wrapper where open applies the given stream to flow
 	private final S stream;
 	
-	public SimpleStream(S stream) {
+	public SimpleStreamContainer(S stream) {
 		this.stream = stream;
 	}
 	

--- a/src/main/java/gov/cida/cdat/io/stream/StatusStreamContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/StatusStreamContainer.java
@@ -4,9 +4,9 @@ import gov.cida.cdat.io.StatusOutputStream;
 
 import java.io.OutputStream;
 
-public class StatusStream extends ChainedStream<StatusOutputStream> {
+public class StatusStreamContainer extends ChainedStreamContainer<StatusOutputStream> {
 
-	public StatusStream(StreamContainer<OutputStream> target) {
+	public StatusStreamContainer(StreamContainer<OutputStream> target) {
 		super(target);
 	}
 

--- a/src/main/java/gov/cida/cdat/io/stream/TransformStreamContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/TransformStreamContainer.java
@@ -6,12 +6,12 @@ import gov.cida.cdat.transform.Transformer;
 
 import java.io.OutputStream;
 
-public class TransformStream extends StreamContainer<TransformOutputStream> {
+public class TransformStreamContainer extends StreamContainer<TransformOutputStream> {
 
 	private OutputStream stream;
 	private Transformer transform;
 	
-	public TransformStream(Transformer transform, OutputStream stream) {
+	public TransformStreamContainer(Transformer transform, OutputStream stream) {
 		this.stream = stream;
 		this.transform = transform;
 	}

--- a/src/main/java/gov/cida/cdat/io/stream/UrlStreamContainer.java
+++ b/src/main/java/gov/cida/cdat/io/stream/UrlStreamContainer.java
@@ -7,11 +7,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-public class UrlStream extends StreamContainer<InputStream> {
+public class UrlStreamContainer extends StreamContainer<InputStream> {
 
 	private final URL url;
 	
-	public UrlStream(URL url) {
+	public UrlStreamContainer(URL url) {
 		this.url = url;
 	}
 

--- a/src/main/java/gov/cida/cdat/service/PipeWorker.java
+++ b/src/main/java/gov/cida/cdat/service/PipeWorker.java
@@ -20,7 +20,7 @@ public class PipeWorker extends Worker {
 	@Override
 	public boolean process() throws CdatException {
 		super.process();
-		boolean isMore = pipe.process(500); // asdf TODO this need to be a real amount of time
+		boolean isMore = pipe.process();
 		return isMore;
 	}
 	

--- a/src/main/java/gov/cida/cdat/service/Registry.java
+++ b/src/main/java/gov/cida/cdat/service/Registry.java
@@ -1,4 +1,4 @@
-package gov.cida.cdat.io.stream;
+package gov.cida.cdat.service;
 
 
 import gov.cida.cdat.control.Status;

--- a/src/main/java/gov/cida/cdat/service/Session.java
+++ b/src/main/java/gov/cida/cdat/service/Session.java
@@ -8,7 +8,6 @@ import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
 import gov.cida.cdat.control.Status;
 import gov.cida.cdat.exception.CdatException;
-import gov.cida.cdat.io.stream.Registry;
 import gov.cida.cdat.message.AddWorkerMessage;
 import gov.cida.cdat.message.Message;
 

--- a/src/main/java/gov/cida/cdat/service/Session.java
+++ b/src/main/java/gov/cida/cdat/service/Session.java
@@ -43,13 +43,15 @@ public class Session extends UntypedActor {
 	
 	
 	// TODO impl start/stop fail return true/false and the Actor supervisor
-	SupervisorStrategy supervisor = new OneForOneStrategy(10, // TEN errors in duration
+	SupervisorStrategy supervisor = new OneForOneStrategy(10, // TEN errors in duration // TODO make configure
 			SCManager.MINUTE, // TODO make configure
 			new Function<Throwable, Directive>() {
 		@Override
 		public Directive apply(Throwable t) {
+			System.out.println("session receved an exception");
 			logger.warn("session receved an exception");
 			
+			// TODO this is only called for un-handled exceptions.
 			// TODO proper handling - this is to inspect how this API works
 			if (t instanceof Exception) {
 				logger.warn("session receved an exception, resuming");
@@ -65,6 +67,7 @@ public class Session extends UntypedActor {
 	});
 	@Override
 	public SupervisorStrategy supervisorStrategy() {
+		logger.info("SupervisorStrategy fetched {}", supervisor);
 		return supervisor;
 	}
 	

--- a/src/test/java/gov/cida/cdat/TestControlFail.java
+++ b/src/test/java/gov/cida/cdat/TestControlFail.java
@@ -5,8 +5,8 @@ import gov.cida.cdat.control.Callback;
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
 import gov.cida.cdat.io.stream.DataPipe;
-import gov.cida.cdat.io.stream.SimpleStream;
-import gov.cida.cdat.io.stream.UrlStream;
+import gov.cida.cdat.io.stream.SimpleStreamContainer;
+import gov.cida.cdat.io.stream.UrlStreamContainer;
 import gov.cida.cdat.message.Message;
 
 import java.io.ByteArrayOutputStream;
@@ -26,11 +26,11 @@ public class TestControlFail {
 
 		// consumer
 		target = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream>     out = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream>     out = new SimpleStreamContainer<OutputStream>(target);
 		
 		// producer
 		URL url = new URL("http://www.asdfsdfasdf.com");
-		UrlStream in = new UrlStream(url);
+		UrlStreamContainer in = new UrlStreamContainer(url);
 		
 		// pipe
 		DataPipe pipe = new DataPipe(in, out);

--- a/src/test/java/gov/cida/cdat/TestControlFail.java
+++ b/src/test/java/gov/cida/cdat/TestControlFail.java
@@ -4,14 +4,15 @@ package gov.cida.cdat;
 import gov.cida.cdat.control.Callback;
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
+import gov.cida.cdat.control.Status;
 import gov.cida.cdat.io.stream.DataPipe;
 import gov.cida.cdat.io.stream.SimpleStreamContainer;
-import gov.cida.cdat.io.stream.UrlStreamContainer;
 import gov.cida.cdat.message.Message;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URL;
 
 // TODO ensure that the fail is handled by the session strategy and that the worker is disposed
 public class TestControlFail {
@@ -29,13 +30,18 @@ public class TestControlFail {
 		SimpleStreamContainer<OutputStream>     out = new SimpleStreamContainer<OutputStream>(target);
 		
 		// producer
-		URL url = new URL("http://www.asdfsdfasdf.com");
-		UrlStreamContainer in = new UrlStreamContainer(url);
+		InputStream error = new InputStream() {
+			@Override
+			public int read() throws IOException {
+				throw new IOException();
+			}
+		};
+		SimpleStreamContainer<InputStream> in = new SimpleStreamContainer<InputStream>(error);
 		
 		// pipe
 		DataPipe pipe = new DataPipe(in, out);
 		
-		workerName = manager.addWorker("google", pipe);
+		workerName = manager.addWorker("error", pipe);
 		
 		manager.send(workerName, Message.create("Message", "Test"));
 		manager.send(workerName, Control.Start);
@@ -62,6 +68,13 @@ public class TestControlFail {
 		System.out.println( "total bytes: " +target.size() );
 		System.out.println( new String(target.toByteArray()) );
 		
+		String qual = "NOT ";
+		if (null != response.get(Status.isError)) {
+			qual = "";
+		}
+		System.out.println("response message DOES " +qual+ "contain isError message" );
+		System.out.println("response isError => " + response.get(Status.isError) );
+
 		System.out.println();
 		System.out.println();
 	}

--- a/src/test/java/gov/cida/cdat/TestControlInterrupt.java
+++ b/src/test/java/gov/cida/cdat/TestControlInterrupt.java
@@ -3,9 +3,9 @@ package gov.cida.cdat;
 
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
-import gov.cida.cdat.io.stream.FileStream;
+import gov.cida.cdat.io.stream.FileStreamContainer;
 import gov.cida.cdat.io.stream.DataPipe;
-import gov.cida.cdat.io.stream.SimpleStream;
+import gov.cida.cdat.io.stream.SimpleStreamContainer;
 import gov.cida.cdat.message.Message;
 
 import java.io.ByteArrayOutputStream;
@@ -20,7 +20,7 @@ public class TestControlInterrupt {
 
 		// consumer
 		ByteArrayOutputStream      target   = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream> consumer = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream> consumer = new SimpleStreamContainer<OutputStream>(target);
 		
 		// producer
 		File file = new File("lib/akka/scalatest_2.11-2.1.3.jar");
@@ -32,7 +32,7 @@ public class TestControlInterrupt {
 			System.exit(1);
 		}
 		
-		FileStream producer = new FileStream(file);
+		FileStreamContainer producer = new FileStreamContainer(file);
 		
 		// pipe
 		final DataPipe pipe = new DataPipe(producer, consumer);

--- a/src/test/java/gov/cida/cdat/TestControlStop.java
+++ b/src/test/java/gov/cida/cdat/TestControlStop.java
@@ -4,8 +4,8 @@ package gov.cida.cdat;
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
 import gov.cida.cdat.io.stream.DataPipe;
-import gov.cida.cdat.io.stream.SimpleStream;
-import gov.cida.cdat.io.stream.UrlStream;
+import gov.cida.cdat.io.stream.SimpleStreamContainer;
+import gov.cida.cdat.io.stream.UrlStreamContainer;
 import gov.cida.cdat.message.Message;
 
 import java.io.ByteArrayOutputStream;
@@ -20,11 +20,11 @@ public class TestControlStop {
 
 		// consumer
 		ByteArrayOutputStream      target = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream> out  = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream> out  = new SimpleStreamContainer<OutputStream>(target);
 		
 		// producer
 		URL url = new URL("http://www.google.com");
-		UrlStream google = new UrlStream(url);
+		UrlStreamContainer google = new UrlStreamContainer(url);
 		
 		// pipe
 		final DataPipe pipe = new DataPipe(google, out);

--- a/src/test/java/gov/cida/cdat/TestControlSuccess.java
+++ b/src/test/java/gov/cida/cdat/TestControlSuccess.java
@@ -5,8 +5,8 @@ import gov.cida.cdat.control.Callback;
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
 import gov.cida.cdat.io.stream.DataPipe;
-import gov.cida.cdat.io.stream.SimpleStream;
-import gov.cida.cdat.io.stream.UrlStream;
+import gov.cida.cdat.io.stream.SimpleStreamContainer;
+import gov.cida.cdat.io.stream.UrlStreamContainer;
 import gov.cida.cdat.message.Message;
 
 import java.io.ByteArrayOutputStream;
@@ -25,11 +25,11 @@ public class TestControlSuccess {
 
 		// consumer
 		target = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream>     out = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream>     out = new SimpleStreamContainer<OutputStream>(target);
 		
 		// producer
 		URL url = new URL("http://www.google.com");
-		UrlStream in = new UrlStream(url);
+		UrlStreamContainer in = new UrlStreamContainer(url);
 		
 		// pipe
 		DataPipe pipe = new DataPipe(in, out);

--- a/src/test/java/gov/cida/cdat/TestControlThreaded.java
+++ b/src/test/java/gov/cida/cdat/TestControlThreaded.java
@@ -5,8 +5,8 @@ import gov.cida.cdat.control.Callback;
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
 import gov.cida.cdat.io.stream.DataPipe;
-import gov.cida.cdat.io.stream.SimpleStream;
-import gov.cida.cdat.io.stream.UrlStream;
+import gov.cida.cdat.io.stream.SimpleStreamContainer;
+import gov.cida.cdat.io.stream.UrlStreamContainer;
 import gov.cida.cdat.message.Message;
 
 import java.io.ByteArrayOutputStream;
@@ -68,11 +68,11 @@ public class TestControlThreaded {
 	private static void submitJob() throws MalformedURLException {
 		// consumer
 		target = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream>     out = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream>     out = new SimpleStreamContainer<OutputStream>(target);
 		
 		// producer
 		URL url = new URL("http://www.google.com");
-		UrlStream in = new UrlStream(url);
+		UrlStreamContainer in = new UrlStreamContainer(url);
 		
 		// pipe
 		DataPipe pipe = new DataPipe(in, out);

--- a/src/test/java/gov/cida/cdat/control/SCManagerTests.java
+++ b/src/test/java/gov/cida/cdat/control/SCManagerTests.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import gov.cida.cdat.io.stream.DataPipe;
-import gov.cida.cdat.io.stream.SimpleStream;
+import gov.cida.cdat.io.stream.SimpleStreamContainer;
 import gov.cida.cdat.message.AddWorkerMessage;
 import gov.cida.cdat.message.Message;
 import gov.cida.cdat.service.Naming;
@@ -69,11 +69,11 @@ public class SCManagerTests {
 		
 		// set up consumer
 		testPipe.consumer = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream> out = new SimpleStream<OutputStream>(testPipe.consumer);
+		SimpleStreamContainer<OutputStream> out = new SimpleStreamContainer<OutputStream>(testPipe.consumer);
 		
 		// set up producer
 		testPipe.producer  = new ByteArrayInputStream(textString.getBytes());
-		SimpleStream<InputStream>   in = new SimpleStream<InputStream>(testPipe.producer);
+		SimpleStreamContainer<InputStream>   in = new SimpleStreamContainer<InputStream>(testPipe.producer);
 		
 		// pipe: connect the consumer and producer together with a data pump
 		testPipe.pipe = new DataPipe(in, out);

--- a/src/test/java/gov/cida/cdat/io/stream/TestStatusStreams.java
+++ b/src/test/java/gov/cida/cdat/io/stream/TestStatusStreams.java
@@ -19,10 +19,10 @@ public class TestStatusStreams {
 		
 		// consumer
 		ByteArrayOutputStream      target   = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream> consumer = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream> consumer = new SimpleStreamContainer<OutputStream>(target);
 
 		// status chained stream
-		final StatusStream status = new StatusStream(consumer);
+		final StatusStreamContainer status = new StatusStreamContainer(consumer);
 		
 		// chained container class example - it works too but the line above is more concise
 //		final ChainedStream<StatusOutputStream> status =
@@ -35,7 +35,7 @@ public class TestStatusStreams {
 		
 		// producer
 		URL url = new URL("http://www.google.com");
-		UrlStream google = new UrlStream(url);
+		UrlStreamContainer google = new UrlStreamContainer(url);
 		
 		// pipe
 		final DataPipe pipe = new DataPipe(google, status);

--- a/src/test/java/gov/cida/cdat/io/stream/TestStreamTransform.java
+++ b/src/test/java/gov/cida/cdat/io/stream/TestStreamTransform.java
@@ -27,11 +27,11 @@ public class TestStreamTransform {
 		Transformer transform = new RegexTransformer("div","span");
 		TransformOutputStream tout = new TransformOutputStream(target, transform);
 
-		SimpleStream<OutputStream> out  = new SimpleStream<OutputStream>(tout);
+		SimpleStreamContainer<OutputStream> out  = new SimpleStreamContainer<OutputStream>(tout);
 
 		// Producer
 		URL url = new URL("http://www.google.com");
-		UrlStream google = new UrlStream(url);
+		UrlStreamContainer google = new UrlStreamContainer(url);
 		
 		// Pipe producer to consumer
 		final DataPipe pipe = new DataPipe(google, out);

--- a/src/test/java/gov/cida/cdat/io/stream/TestStreams.java
+++ b/src/test/java/gov/cida/cdat/io/stream/TestStreams.java
@@ -19,11 +19,11 @@ public class TestStreams {
 		
 		// consumer
 		ByteArrayOutputStream      target   = new ByteArrayOutputStream(1024*10);
-		SimpleStream<OutputStream> consumer = new SimpleStream<OutputStream>(target);
+		SimpleStreamContainer<OutputStream> consumer = new SimpleStreamContainer<OutputStream>(target);
 
 		// producer
 		URL url = new URL("http://www.google.com");
-		UrlStream google = new UrlStream(url);
+		UrlStreamContainer google = new UrlStreamContainer(url);
 		
 		// pipe
 		final DataPipe pipe = new DataPipe(google, consumer);


### PR DESCRIPTION
In this pull request I have added a split stream for cache consumer. We still need a cache producer; data fetch must first hit the cache and then hit the origin if necessary. Added 'Container' to all StreamContainer subclasses

The error handling is managed in the return message at this time. However, I foresee a possibility of adding a method to Worker for handling or revising to an AKKA strategy.

Also, removed testing Thread.sleep calls.