### PR TITLE
Cleanup - final prep for first release

### DIFF
--- a/src/main/java/gov/cida/cdat/control/Control.java
+++ b/src/main/java/gov/cida/cdat/control/Control.java
@@ -13,5 +13,5 @@ import gov.cida.cdat.message.Message;
  * @see Status
  */
 public enum Control {
-	Start, Stop, onComplete;
+	Start, Stop, onComplete, info, CurrentStatus;
 }

--- a/src/main/java/gov/cida/cdat/control/Control.java
+++ b/src/main/java/gov/cida/cdat/control/Control.java
@@ -13,5 +13,5 @@ import gov.cida.cdat.message.Message;
  * @see Status
  */
 public enum Control {
-	Start, Stop, onComplete, info, CurrentStatus;
+	Start, Stop, onComplete, info, history, CurrentStatus;
 }

--- a/src/main/java/gov/cida/cdat/control/SCManager.java
+++ b/src/main/java/gov/cida/cdat/control/SCManager.java
@@ -388,6 +388,17 @@ public class SCManager {
 		Message msg = Message.create(ctrl);
 		return send(workerName, msg);
 	}
+	public Message request(String workerName, Message msg) {
+		Future<Object> future = send(workerName, msg);
+		Object result = null;
+		try {
+			result = Await.result(future, Time.SECOND); // TODO make configure
+		} catch (Exception e) {
+			result = Message.create("error",e.getMessage());
+		}
+		return (Message)result;
+	}
+	
 	/**
 	 * <p>Enumerated control message</p>
 	 * <p>A convenience send for Control enum standard messages. It saves the user from requiring
@@ -417,14 +428,7 @@ public class SCManager {
 	 */
 	public Message send(String workerName, Status status) {
 		Message msg = Message.create(status);
-		Future<Object> future = send(workerName, msg);
-		Object result = null;
-		try {
-			result = Await.result(future, Time.SECOND); // TODO make configure
-		} catch (Exception e) {
-			result = Message.create("error",e.getMessage());
-		}
-		return (Message)result;
+		return request(workerName, msg);
 	}
 	/**
 	 * <p>Enumerated status message (non-blocking)</p>

--- a/src/main/java/gov/cida/cdat/control/SCManager.java
+++ b/src/main/java/gov/cida/cdat/control/SCManager.java
@@ -368,7 +368,7 @@ public class SCManager {
 	 * @return a future that contains a Message response from the worker upon completion or exception
 	 */
 	public Future<Object> send(String workerName, Message message, Timeout waitTime) {
-		message = Message.extend(message, Naming.WORKER_NAME, workerName);
+		message = message.extend(Naming.WORKER_NAME, workerName);
 	    return Patterns.ask(session(workerName), message, waitTime);
 	}
 	

--- a/src/main/java/gov/cida/cdat/control/Status.java
+++ b/src/main/java/gov/cida/cdat/control/Status.java
@@ -13,7 +13,7 @@ import gov.cida.cdat.message.Message;
  * @see Control
  */
 public enum Status {
-	info,CurrentStatus,isNew,isStarted,isAlive,isDone,isError,isDisposed;
+	isNew,isStarted,isAlive,isDone,isError,isDisposed;
 	
 	// cannot override equals
 	public boolean is(Object other) {
@@ -24,5 +24,12 @@ public enum Status {
 			return toString().equalsIgnoreCase((String)other);
 		}
 		return super.equals(other);
+	}
+
+	public static boolean isAlive(Status status) {
+		if (status == null) {
+			return false;
+		}
+		return (Status.isAlive.ordinal() >= status.ordinal());
 	}
 }

--- a/src/main/java/gov/cida/cdat/db/DbReader.java
+++ b/src/main/java/gov/cida/cdat/db/DbReader.java
@@ -16,7 +16,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public abstract class DbReader<T> implements Closeable, Openable<OutputStream> {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	protected Connection conn;
 	protected int fetchSize;
@@ -41,7 +45,7 @@ public abstract class DbReader<T> implements Closeable, Openable<OutputStream> {
 	
 	@Override
 	public OutputStream open() throws StreamInitException {
-		System.out.println("DbReader open");
+		logger.trace("DbReader open");
 		
 		target = transformer.open();
 		try {
@@ -58,7 +62,7 @@ public abstract class DbReader<T> implements Closeable, Openable<OutputStream> {
 	
 	
 	public boolean read() throws CdatException {
-		System.out.println("DbReader read");
+		logger.trace("DbReader read");
 
 		if (target == null) {
 			throw new StreamInitException("Must call open before reading");
@@ -83,7 +87,7 @@ public abstract class DbReader<T> implements Closeable, Openable<OutputStream> {
 	
 	@Override
 	public void close() throws IOException {
-		System.out.println("DbReader close");
+		logger.trace("DbReader close");
 		
 		Closer.close(transformer);
 		Closer.close(target);

--- a/src/main/java/gov/cida/cdat/message/Message.java
+++ b/src/main/java/gov/cida/cdat/message/Message.java
@@ -113,6 +113,9 @@ public class Message implements Serializable {
 		msg.message.put(name.toString(), value);
 		return msg;
 	}
+	public Message extend(Object name, String value) {
+		return extend(this,name,value);
+	}
 	/**
 	 * convenience method for creating a boolean qualifier
 	 * @param name message name
@@ -212,5 +215,9 @@ public class Message implements Serializable {
 		String caller = last.getClassName() +"."+ last.getMethodName() 
 				+":"+ last.getLineNumber();
 		message.put("TRACE", caller);
+	}
+	
+	public int size() {
+		return message.size();
 	}
 }

--- a/src/main/java/gov/cida/cdat/service/Delegator.java
+++ b/src/main/java/gov/cida/cdat/service/Delegator.java
@@ -30,11 +30,20 @@ public class Delegator extends UntypedActor {
 	/**
 	 * The message name for processing more or CONTINUE
 	 */
-	private static final String  PROCESS_MORE = "process.more";
+	private static final String  PROCESS_MORE   = "process.more";
 	/**
 	 * The message to continue processing more data
 	 */
-	private static final Message CONTINUE     = Message.create(PROCESS_MORE);
+	private static final Message CONTINUE       = Message.create(PROCESS_MORE);
+
+	/**
+	 * The message name for processing status update
+	 */
+	public static final String  PROCESS_STATUS = "STATUS";
+	/**
+	 * The message to update process status DONE
+	 */
+	private static final Message DONE           = Message.create(PROCESS_STATUS,Status.isDone);
 
 	/**
 	 * This is the unique name given when the delegate worker.
@@ -294,6 +303,7 @@ public class Delegator extends UntypedActor {
 		try {
 			worker.end();
 			setStatus(Status.isDone);
+			context().parent().tell(DONE.extend(Naming.WORKER_NAME, getName()), self());
 		} catch (Exception e) {
 			setCurrentError(e);
 		} finally {

--- a/src/main/java/gov/cida/cdat/service/Delegator.java
+++ b/src/main/java/gov/cida/cdat/service/Delegator.java
@@ -137,8 +137,8 @@ public class Delegator extends UntypedActor {
 			response = Message.create(Status.isAlive, true);
 		} else if (msg.contains(Status.isDone)) {
 			response = createStatusMessage(Status.isDone);
-		} else if (msg.contains(Status.CurrentStatus)) {
-			response = Message.create(Status.CurrentStatus, status);
+		} else if (msg.contains(Control.CurrentStatus)) {
+			response = Message.create(Control.CurrentStatus, status);
 		}
 		
 		// handle onComplete requests

--- a/src/main/java/gov/cida/cdat/service/Delegator.java
+++ b/src/main/java/gov/cida/cdat/service/Delegator.java
@@ -322,7 +322,7 @@ public class Delegator extends UntypedActor {
 		if (currentError != null) {
 			value = "error";
 			String exceptionMessage = createExceptionMessage(currentError);
-			completed = Message.extend(completed, Status.isError, exceptionMessage);
+			completed = completed.extend(Status.isError, exceptionMessage);
 		}
 		completed = Message.extend(completed, Control.onComplete, value);
 		needsToKnow.tell(completed, self());

--- a/src/main/java/gov/cida/cdat/service/Registry.java
+++ b/src/main/java/gov/cida/cdat/service/Registry.java
@@ -37,27 +37,12 @@ public class Registry {
 	}
 	
 	public String put(String name, ActorRef actor) {
-		String uniqueName = createUniqueName(name);
-		workers.put(uniqueName, new WeakReference<ActorRef>(actor));
+		workers.put(name, new WeakReference<ActorRef>(actor));
 		setStatus(name, Status.isNew);
 
 		return name;
 	}
 
-	// package access for testing
-	String createUniqueName(String name) {
-		int count = 0; // internal count auto-named entries
-		
-		String uniqueName = name;
-		
-		while ( workers.containsKey(uniqueName) || stati.containsKey(uniqueName) ) {
-			uniqueName = name + (count++);
-		}
-		
-		return uniqueName;
-	}
-
-	
 	public void setStatus(String name, String status) {
 		if (stati.get(name) != null) {
 			Status current = Status.valueOf(stati.get(name));

--- a/src/main/java/gov/cida/cdat/service/Registry.java
+++ b/src/main/java/gov/cida/cdat/service/Registry.java
@@ -2,6 +2,7 @@ package gov.cida.cdat.service;
 
 
 import gov.cida.cdat.control.Status;
+import gov.cida.cdat.control.Time;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -17,11 +18,39 @@ public class Registry {
 	
 	final Map<String,WeakReference<ActorRef>> workers;
 	final Map<String,Status>   stati;
+	final Map<String,Map<Status,Long>>   history;
 	
 	public Registry() {
 		// when objects get GC'ed they will not be held in this registry
 		workers = new WeakHashMap<String, WeakReference<ActorRef>>();
 		stati   = new HashMap<String, Status>();
+		history = new HashMap<String, Map<Status,Long>>(){
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String toString() {
+				StringBuilder buff = new StringBuilder().append("history::");
+				for (String name : keySet()) {
+					buff.append(name).append(" :\n");
+					for (Status stat : Status.values()) {
+						Long time = get(name).get(stat);
+						buff.append('\t').append(stat.toString())
+							.append(" - ").append(time==null?"":time.toString())
+							.append('\n');
+					}
+					if (null != get(name).get(Status.isDone)) {
+						long runtime = get(name).get(Status.isDone)-get(name).get(Status.isStarted);
+						buff.append('\t').append("runtime - ").append(runtime).append('\n');
+					}
+					if (null != get(name).get(Status.isDisposed)) {
+						long lifespan = get(name).get(Status.isDisposed)-get(name).get(Status.isNew);
+						buff.append('\t').append("lifespan - ").append(lifespan).append('\n');
+					}
+				}
+				
+				return buff.toString();
+			}
+		};
 	}
 	
 	public ActorRef get(String name) {
@@ -40,6 +69,7 @@ public class Registry {
 	
 	public String put(String name, ActorRef actor) {
 		workers.put(name, new WeakReference<ActorRef>(actor));
+		history.put(name, new HashMap<Status,Long>());
 		setStatus(name, Status.isNew);
 
 		return name;
@@ -53,13 +83,13 @@ public class Registry {
 		if (stati.get(name) != null) {
 			Status current = stati.get(name);
 			if (newStatus.ordinal() < current.ordinal()) {
-				// we only accept status further towards dispose
-				return;
+				return; // we only accept after the current status, closer to dispose
 			}
 		}
 		
 		stati.remove(name);
 		stati.put(name, newStatus);
+		history.get(name).put(newStatus, Time.now());
 		
 		// remove not alive workers
 //		if ( ! Status.isAlive(newStatus) ) {
@@ -82,5 +112,14 @@ public class Registry {
 		names.addAll(workers.keySet());
 		
 		return names;
+	}
+	
+	public Map<Status,Long> getHistory(String name) {
+		Map<Status, Long> workerHistory = new HashMap<Status, Long>();
+		
+		if (history.get(name) != null) {
+			workerHistory.putAll( history.get(name) );
+		}
+		return workerHistory;
 	}
 }

--- a/src/main/java/gov/cida/cdat/service/Session.java
+++ b/src/main/java/gov/cida/cdat/service/Session.java
@@ -196,7 +196,7 @@ public class Session extends UntypedActor {
 			if (delegates>0  &&  attempts++<100) {
 				logger.trace("jobs remain running on {}", self().path().name());
 				Thread.sleep( Time.MILLIS.toMillis() ); // TODO make configurable
-				msg = Message.extend(msg, "attempts", ""+attempts);
+				msg = msg.extend("attempts", ""+attempts);
 				self().tell(msg, self());
 			} else {
 				logger.trace("no works waiting to finish - stopping session {}", self().path().name());

--- a/src/main/java/gov/cida/cdat/service/Session.java
+++ b/src/main/java/gov/cida/cdat/service/Session.java
@@ -120,6 +120,11 @@ public class Session extends UntypedActor {
 			sender().tell(response, self());
 			return;
 		}
+		if ( msg.contains(Delegator.PROCESS_STATUS) ) {
+			Status status = Status.valueOf(msg.get(Delegator.PROCESS_STATUS));
+			delegates.setStatus(msg.get(Naming.WORKER_NAME), status);
+			return;
+		}
 		
 		String workerName = msg.get(Naming.WORKER_NAME);
 

--- a/src/test/java/gov/cida/cdat/service/DelegatorStatusTests.java
+++ b/src/test/java/gov/cida/cdat/service/DelegatorStatusTests.java
@@ -40,12 +40,12 @@ public class DelegatorStatusTests {
 			assertTrue("Expect the delegate be NEW", 
 					response.get(Status.isNew).equals("true"));
 			
-			response = session.send(workerName, Status.CurrentStatus);
+			response = session.request(workerName, Message.create(Control.CurrentStatus));
 			TestUtils.log("send status CurrentStatus - expect isNew", response);
 			assertTrue("Expect the delegate respond with CurrentStatus message", 
-					response.contains(Status.CurrentStatus));
+					response.contains(Control.CurrentStatus));
 			assertTrue("Expect the delegate be isNew", 
-					response.get(Status.CurrentStatus).equals("isNew"));
+					response.get(Control.CurrentStatus).equals("isNew"));
 			
 			response = session.send(workerName, Status.isStarted);
 			TestUtils.log("send status isStarted - expect false", response);
@@ -79,12 +79,12 @@ public class DelegatorStatusTests {
 			assertTrue("Expect the delegate be NEW", 
 					response.get(Status.isNew).equals("false"));
 			
-			response = session.send(workerName, Status.CurrentStatus);
+			response = session.request(workerName, Message.create(Control.CurrentStatus));
 			TestUtils.log("send status CurrentStatus - expect isStarted", response);
 			assertTrue("Expect the delegate respond with CurrentStatus message", 
-					response.contains(Status.CurrentStatus));
+					response.contains(Control.CurrentStatus));
 			assertTrue("Expect the delegate be isStarted", 
-					response.get(Status.CurrentStatus).equals("isStarted"));
+					response.get(Control.CurrentStatus).equals("isStarted"));
 			
 			response = session.send(workerName, Status.isStarted);
 			TestUtils.log("send status isStarted - expect true", response);

--- a/src/test/java/gov/cida/cdat/service/SessionInfoTests.java
+++ b/src/test/java/gov/cida/cdat/service/SessionInfoTests.java
@@ -136,7 +136,7 @@ public class SessionInfoTests {
 			
 			assertEquals("Expect info on workerA to be "+Status.isStarted,
 					Status.isStarted.toString(), message[0].get(nameA));
-			assertEquals("Expect info on workerB to be "+Status.isDisposed,
+			assertEquals("Expect info on workerB to be "+Status.isStarted,
 					Status.isStarted.toString(), message[0].get(nameB));
 		} finally {
 			session.close();

--- a/src/test/java/gov/cida/cdat/service/SessionInfoTests.java
+++ b/src/test/java/gov/cida/cdat/service/SessionInfoTests.java
@@ -25,7 +25,7 @@ public class SessionInfoTests {
 			String nameB = session.addWorker("workerB", workerB);
 			
 			final Message[] message = new Message[1];
-			Message getInfo = Message.create(Status.info, SCManager.SESSION);
+			Message getInfo = Message.create(Control.info, SCManager.SESSION);
 			session.send(SCManager.SESSION, getInfo, new Callback() {
 				@Override
 				public void onComplete(Throwable t, Message response) {
@@ -58,7 +58,7 @@ public class SessionInfoTests {
 			String nameB = session.addWorker("workerB", workerB);
 			
 			final Message[] message = new Message[1];
-			Message getInfo = Message.create(Status.info, SCManager.SESSION);
+			Message getInfo = Message.create(Control.info, SCManager.SESSION);
 			
 			session.send(nameA, Control.Start);
 			session.send(nameB, Control.Start);
@@ -120,7 +120,7 @@ public class SessionInfoTests {
 			String nameB = session.addWorker("workerB", workerB);
 			
 			final Message[] message = new Message[1];
-			Message getInfo = Message.create(Status.info, SCManager.SESSION);
+			Message getInfo = Message.create(Control.info, SCManager.SESSION);
 			
 			
 			session.send(SCManager.SESSION, getInfo, new Callback() {

--- a/src/test/java/gov/cida/cdat/service/SessionWorkerHistoryTests.java
+++ b/src/test/java/gov/cida/cdat/service/SessionWorkerHistoryTests.java
@@ -1,0 +1,166 @@
+package gov.cida.cdat.service;
+
+import static org.junit.Assert.*;
+import gov.cida.cdat.TestUtils;
+import gov.cida.cdat.control.Callback;
+import gov.cida.cdat.control.Control;
+import gov.cida.cdat.control.SCManager;
+import gov.cida.cdat.control.Status;
+import gov.cida.cdat.exception.CdatException;
+import gov.cida.cdat.message.Message;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SessionWorkerHistoryTests {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+	
+	
+	private int traceEntry;
+	
+	@Before
+	public void setup() {
+		if (logger.isTraceEnabled()) {
+			traceEntry=1;
+		}		
+	}
+	
+	
+	private Message[] getWorkerHostory(SCManager session, String nameA, String nameB) {
+		final Message[] messages = new Message[2];
+		Message getHistoryA = Message.create(Control.history, nameA);
+		session.send(nameA, getHistoryA, new Callback() {
+			@Override
+			public void onComplete(Throwable t, Message response) {
+				messages[0] = response;
+			}
+		});
+		Message getHistoryB = Message.create(Control.history, nameB);
+		session.send(nameB, getHistoryB, new Callback() {
+			@Override
+			public void onComplete(Throwable t, Message response) {
+				messages[1] = response;
+			}
+		});
+		
+		TestUtils.waitAlittleWhileForResponse(messages);
+		
+		TestUtils.log(messages[0]);
+		TestUtils.log(messages[1]);
+		
+		return messages;
+	}
+	
+	@Test
+	public void testInfoIsNew() {
+		SCManager session = SCManager.open();
+		
+		try {
+			Worker workerA = new Worker(){};
+			Worker workerB = new Worker(){};
+			
+			String nameA = session.addWorker("workerA", workerA);
+			String nameB = session.addWorker("workerB", workerB);
+			
+			Message[] history = getWorkerHostory(session, nameA, nameB);
+				
+			
+			assertEquals("Expect workerA history contain only "+Status.isNew,
+					 1+traceEntry, history[0].size());
+			assertTrue("Expect workerA history contain only "+Status.isNew,
+					 history[0].get(Status.isNew) != null);
+
+			assertEquals("Expect workerB history contain only "+Status.isNew,
+					 1+traceEntry, history[1].size());
+			assertTrue("Expect workerB history contain only "+Status.isNew,
+					 history[1].get(Status.isNew) != null);
+		} finally {
+			session.close();
+		}
+	}
+		
+
+	@Test
+	public void testInfoIsDisposed() throws Exception {
+		SCManager session = SCManager.open();
+		
+		try {
+			Worker workerA = new Worker(){};
+			Worker workerB = new Worker(){};
+			
+			String nameA = session.addWorker("workerA", workerA);
+			String nameB = session.addWorker("workerB", workerB);
+						
+			session.send(nameA, Control.Start);
+			
+			Thread.sleep(100);
+			
+			Message[] history = getWorkerHostory(session, nameA, nameB);
+			
+			assertEquals("Expect workerA history contain status - isNew,isStarted,isDone,isDispose,lifespan,runtime",
+					 6+traceEntry, history[0].size());
+			assertTrue("Expect workerA history contain "+Status.isNew,
+					 history[0].get(Status.isNew) != null);
+			assertTrue("Expect workerA history contain "+Status.isStarted,
+					 history[0].get(Status.isStarted) != null);
+			assertTrue("Expect workerA history contain "+Status.isDone,
+					 history[0].get(Status.isDone) != null);
+			assertTrue("Expect workerA history contain "+Status.isDisposed,
+					 history[0].get(Status.isDisposed) != null);
+			assertTrue("Expect workerA history contain runtime",
+					 history[0].get("runtime") != null);
+			assertTrue("Expect workerA history contain lifespan",
+					 history[0].get("lifespan") != null);
+
+			assertEquals("Expect workerB history contain only "+Status.isNew,
+					 1+traceEntry, history[1].size());
+			assertTrue("Expect workerB history contain only "+Status.isNew,
+					 history[1].get(Status.isNew) != null);
+		} finally {
+			session.close();
+		}
+	}
+	
+	
+	@Test
+	public void testInfoIsStarted() throws Exception {
+		SCManager session = SCManager.open();
+		
+		try {			
+			Worker workerA = new Worker(){
+				@Override
+				public boolean process() throws CdatException {
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+					return super.process();
+				}
+			};
+			Worker workerB = new Worker(){};
+			
+			session.setAutoStart(true);
+			String nameA = session.addWorker("workerA", workerA);
+			session.setAutoStart(false);
+			String nameB = session.addWorker("workerB", workerB);
+			
+			Message[] history = getWorkerHostory(session, nameA, nameB);
+			
+			assertEquals("Expect workerA history contain status - isNew,isStarted",
+					 2+traceEntry, history[0].size());
+			assertTrue("Expect workerA history contain "+Status.isNew,
+					 history[0].get(Status.isNew) != null);
+			assertTrue("Expect workerA history contain "+Status.isStarted,
+					 history[0].get(Status.isStarted) != null);
+
+			assertEquals("Expect workerB history contain only "+Status.isNew,
+					 1+traceEntry, history[1].size());
+			assertTrue("Expect workerB history contain only "+Status.isNew,
+					 history[1].get(Status.isNew) != null);
+		} finally {
+			session.close();
+		}
+	}}


### PR DESCRIPTION
removed dead code from registry
refactor Status to only statuses that can be held and the special inquiries moved to Control enum
minor refactor of Message.extend
removed some println calls from initial testing
corrected a test that passed but reported the wrong fail message
delegator now reports isDone to session for full life cycle management
worker status history management - useful for determining performance, etc.