### PR TITLE
expose more wait functionality necessary for WQP to use Spring DeferredResult

### DIFF
--- a/src/main/java/gov/cida/cdat/control/SCManager.java
+++ b/src/main/java/gov/cida/cdat/control/SCManager.java
@@ -1,8 +1,17 @@
 package gov.cida.cdat.control;
 
+import gov.cida.cdat.io.QuietClose;
 import gov.cida.cdat.service.Service;
 
-public class SCManager {
+
+/**
+ * This hides the AKKA library calls.
+ * This delegate simple exists because eclipse will detect the underlying implementation.
+ * 
+ * @author duselmann
+ *
+ */
+public class SCManager implements QuietClose {
 	public final static String SESSION = Service.SESSION;
 
 	private static final Service   scm;
@@ -65,6 +74,14 @@ public class SCManager {
 		return scm.request(workerName, msg);
 	}
 
+	public Message request(String workerName, Message msg, Time maxWait) {
+		return scm.request(workerName, msg, maxWait);
+	}
+	
+	public Message request(String workerName, Message msg, Time maxWait, Callback callback) {
+		return scm.request(workerName, msg, maxWait, callback);
+	}
+
 	public void send(String workerName, Control ctrl, Callback callback) {
 		scm.send(workerName, ctrl, callback);
 	}
@@ -89,8 +106,7 @@ public class SCManager {
 		return scm.waitForComplete(workerName, waitTime);
 	}
 
-	public long waitForComplete(String workerName, long initialWait,
-			long subsequentWait) {
+	public long waitForComplete(String workerName, long initialWait, long subsequentWait) {
 		return scm.waitForComplete(workerName, initialWait, subsequentWait);
 	}
 

--- a/src/main/java/gov/cida/cdat/io/Closer.java
+++ b/src/main/java/gov/cida/cdat/io/Closer.java
@@ -21,4 +21,13 @@ public class Closer {
 			// TODO I know, I know. Never swallow. But really?
 		}
 	}
+	public static void close(QuietClose closeable) {
+		try {
+			if (closeable != null) {
+				closeable.close();
+			}
+		} catch (Exception e) {
+			// TODO I know, I know. Never swallow. But really?
+		}
+	}
 }

--- a/src/main/java/gov/cida/cdat/io/QuietClose.java
+++ b/src/main/java/gov/cida/cdat/io/QuietClose.java
@@ -1,0 +1,6 @@
+package gov.cida.cdat.io;
+
+public interface QuietClose {
+
+	void close();
+}

--- a/src/main/java/gov/cida/cdat/service/Service.java
+++ b/src/main/java/gov/cida/cdat/service/Service.java
@@ -418,10 +418,24 @@ public class Service {
 		send(workerName, msg);
 	}
 	public Message request(String workerName, Message msg) {
+		return request(workerName, msg, Time.SECOND); // TODO make configure
+	}
+	public Message request(String workerName, Message msg, Time maxWait) {
 		Future<Object> future = sendWithFuture(workerName, msg);
 		Object result = null;
 		try {
-			result = Await.result(future, Time.SECOND.duration); // TODO make configure
+			result = Await.result(future, maxWait.duration);
+		} catch (Exception e) {
+			result = Message.create("error",e.getMessage());
+		}
+		return (Message)result;
+	}
+	public Message request(String workerName, Message msg, Time maxWait, Callback callback) {
+		Future<Object> future = sendWithFuture(workerName, msg);
+		wrapCallback(future, workerPool.dispatcher(), callback);
+		Object result = null;
+		try {
+			result = Await.result(future, maxWait.duration);
 		} catch (Exception e) {
 			result = Message.create("error",e.getMessage());
 		}
@@ -605,6 +619,17 @@ public class Service {
 		long duration = Time.duration(start);
 		logger.trace("waited {}ms for {} to complete", duration, workerName);
 		return duration;
+	}
+	
+	public Message waitForComplete(String workerName, Message msg) {
+		Future<Object> future = sendWithFuture(workerName, msg);
+		Object result = null;
+		try {
+			result = Await.result(future, Time.SECOND.duration); // TODO make configure
+		} catch (Exception e) {
+			result = Message.create("error",e.getMessage());
+		}
+		return (Message)result;
 	}
 	
 	


### PR DESCRIPTION
it does NOT make a dependence on Spring. it is just changes required in order to get WQP to wait for worker complete nicely. also of note, there are areas of improvement here. I did not know what method signatures would be useful on writing cDAT; hence, some could be deprecated or removed.