### PR TITLE
CUSTOM Time entry. This is because we want to hide the scala/akka …

### DIFF
--- a/src/main/java/gov/cida/cdat/control/Time.java
+++ b/src/main/java/gov/cida/cdat/control/Time.java
@@ -13,14 +13,22 @@ public enum Time {
 	HALF_MINUTE( 30, "seconds"),
 	MINUTE(  1, "minute"),
 	HOUR(  1, "hour"),
-	DAY(  1, "day");
-		
+	DAY(  1, "day"),
+	CUSTOM( 1, "hour");
+	
+	
 	private static final Logger logger = LoggerFactory.getLogger(Time.class);
 	
-	public final FiniteDuration duration;
+	public FiniteDuration duration;
 	
 	Time(long amount, String unit) {
 		duration =  Duration.create(amount, unit);
+	}
+	
+	public void setDuration(long amount, String unit) {
+		if ("CUSTOM".equals(this.toString())) {
+			duration =  Duration.create(amount, unit);
+		}
 	}
 	
 	public long asMS() {


### PR DESCRIPTION
…Duration class from the implementing project. However, we need to be able to make a custom time. We should probably make a map of cutom times